### PR TITLE
Implement lazy loading for homepage sections

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,8 +7,8 @@ import FeatureSection from '@/components/feature-section';
 import dynamic from 'next/dynamic';
 
 const CasesSection = dynamic(() => import('@/components/cases-section'), { ssr: false });
-import SocialProof from '@/components/social-proof';
-import PricingTable from '@/components/pricing-table';
+const SocialProof = dynamic(() => import('@/components/social-proof'), { ssr: false });
+const PricingTable = dynamic(() => import('@/components/pricing-table'), { ssr: false });
 import Footer from '@/components/footer';
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- lazily load SocialProof and PricingTable components

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn build` *(fails: package not present in lockfile)*


------
https://chatgpt.com/codex/tasks/task_b_68473cf14ef0832fa0a1babf7877a3ee