### PR TITLE
Add email routes and connect pricing to Stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ STRIPE_PRICE_ID=price_123
 STRIPE_WEBHOOK_SECRET=whsec_yourkey
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# API key for Resend transactional emails
+RESEND_API_KEY=your_resend_key
+
 NEXT_PUBLIC_SUPABASE_URL=https://yourproject.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 <br>
 
-A free Next.js TypeScript landing page template for SaaS products, online services and more.
+Ship your startup in days, not weeks. The Next.js boilerplate with all you need to build your SaaS, AI tool, or any other web app and make your first $ online fast.
 
 <a href="https://next-startd.vercel.app">Live demo</a>
 
@@ -60,6 +60,18 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 Supabase handles email/password, Google OAuth and magic link logins. Stripe is
 used to create checkout sessions and process webhooks that update the user's
 subscription status in your database.
+
+### Emails
+
+Use [Resend](https://resend.com) or Mailgun to send transactional emails. Add a
+`RESEND_API_KEY` to your environment and call `/api/send-email` to send emails.
+
+Configure DNS on a subdomain to avoid the spam folder. Set up `SPF`, `DKIM` and
+`DMARC` records with your domain registrar. Resend and Mailgun provide the
+correct values during domain verification.
+
+For inbound mail, point the provider's webhook to `/api/email/webhook` and
+forward messages anywhere you need.
 
 
 ## 🤝 Contributing

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-particles-js": "3.4.1",
+    "resend": "^4.5.2",
     "stripe": "^18.2.1",
     "twind": "0.15.4"
   },

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,6 +1,6 @@
 import { tw } from 'twind';
 
-interface IButton {
+interface IButton extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   primary?: boolean;
   children: React.ReactNode;
   modifier?: string;

--- a/src/components/pricing-table/index.tsx
+++ b/src/components/pricing-table/index.tsx
@@ -58,8 +58,16 @@ const PricingTable = () => (
           <div className={tw(`my-4 flex items-center justify-center text-6xl leading-none font-bold text-gray-800`)}>
             $99/mo
           </div>
-          <Button primary modifier="mt-6">
-            Contact sales
+          <Button
+            primary
+            modifier="mt-6"
+            onClick={async () => {
+              const res = await fetch(`/api/checkout`, { method: `POST` });
+              const data = await res.json();
+              if (data.url) window.location.href = data.url;
+            }}
+          >
+            Subscribe
           </Button>
         </div>
       </div>

--- a/src/pages/api/email/webhook.ts
+++ b/src/pages/api/email/webhook.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== `POST`) {
+    res.setHeader(`Allow`, `POST`);
+    return res.status(405).end(`Method Not Allowed`);
+  }
+
+  // Incoming payload from Resend or Mailgun
+  const payload = req.body;
+  console.log(`Inbound email`, payload);
+  // TODO: forward email using Resend or handle as needed
+
+  return res.status(200).json({ received: true });
+}

--- a/src/pages/api/send-email.ts
+++ b/src/pages/api/send-email.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY || ``);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== `POST`) {
+    res.setHeader(`Allow`, `POST`);
+    return res.status(405).end(`Method Not Allowed`);
+  }
+
+  const { to, subject, html } = req.body;
+
+  try {
+    await resend.emails.send({
+      from: `noreply@${process.env.DOMAIN || `example.com`}`,
+      to,
+      subject,
+      html,
+    });
+    return res.status(200).json({ success: true });
+  } catch (err: any) {
+    return res.status(500).json({ error: `Email send error` });
+  }
+}

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -8,9 +8,7 @@ export const config = {
   },
 };
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || ``, {
-  apiVersion: `2022-11-15`,
-});
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || ``);
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || ``;
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,8 @@ export default function Home() {
     <Page>
       <NextSeo
         title="STARTD - Template"
-        description="A TypeScript/Next.js theme that includes everything you need to build amazing landing page!"
+        // eslint-disable-next-line max-len
+        description="Ship your startup in days, not weeks. The Next.js boilerplate with all you need to build your SaaS, AI tool, or any other web app and make your first $ online fast."
       />
       <Header />
       <main>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,6 +1573,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-email/render@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@react-email/render@npm:1.1.2"
+  dependencies:
+    html-to-text: "npm:^9.0.5"
+    prettier: "npm:^3.5.3"
+    react-promise-suspense: "npm:^0.3.4"
+  peerDependencies:
+    react: ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+  checksum: 10c0/def0039a24b797d962d7dcb3a3401c093aa0115545284e00863de4066a826a3e4977b8f2c65b1f3bf77352bee5595e0dedf166ea52467dcb7080e14785e1c3ac
+  languageName: node
+  linkType: hard
+
+"@selderee/plugin-htmlparser2@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@selderee/plugin-htmlparser2@npm:0.11.0"
+  dependencies:
+    domhandler: "npm:^5.0.3"
+    selderee: "npm:^0.11.0"
+  checksum: 10c0/e938ba9aeb31a9cf30dcb2977ef41685c598bf744bedc88c57aa9e8b7e71b51781695cf99c08aac50773fd7714eba670bd2a079e46db0788abe40c6d220084eb
+  languageName: node
+  linkType: hard
+
 "@supabase/auth-js@npm:2.70.0":
   version: 2.70.0
   resolution: "@supabase/auth-js@npm:2.70.0"
@@ -3091,6 +3115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deepmerge@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
 "define-properties@npm:^1.1.3":
   version: 1.1.3
   resolution: "define-properties@npm:1.1.3"
@@ -3207,6 +3238,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-serializer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "dom-serializer@npm:2.0.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.2"
+    entities: "npm:^4.2.0"
+  checksum: 10c0/d5ae2b7110ca3746b3643d3ef60ef823f5f078667baf530cec096433f1627ec4b6fa8c072f09d079d7cda915fd2c7bc1b7b935681e9b09e591e1e15f4040b8e2
+  languageName: node
+  linkType: hard
+
 "domelementtype@npm:1":
   version: 1.3.1
   resolution: "domelementtype@npm:1.3.1"
@@ -3221,12 +3263,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"domelementtype@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "domelementtype@npm:2.3.0"
+  checksum: 10c0/686f5a9ef0fff078c1412c05db73a0dce096190036f33e400a07e2a4518e9f56b1e324f5c576a0a747ef0e75b5d985c040b0d51945ce780c0dd3c625a18cd8c9
+  languageName: node
+  linkType: hard
+
 "domhandler@npm:^4.0.0":
   version: 4.0.0
   resolution: "domhandler@npm:4.0.0"
   dependencies:
     domelementtype: "npm:^2.1.0"
   checksum: 10c0/4c8e889c0fe4982a18610273ecb89c5c3037a252225af87c04bd91dcc977b5bac6730d42d8f8c77bdaace1cdfbf6492053e29074958a8d36d4ca71a4961391a2
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+  checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
   languageName: node
   linkType: hard
 
@@ -3248,6 +3306,17 @@ __metadata:
     domelementtype: "npm:^2.0.1"
     domhandler: "npm:^4.0.0"
   checksum: 10c0/123f0646a6e8977d85966b97a321c05da257250d9a1c0e4752d84dbe5f2a4e633629645213974c220f5882de19f1f1c05455cc194755b3c14f6782de6b95cd2f
+  languageName: node
+  linkType: hard
+
+"domutils@npm:^3.0.1":
+  version: 3.2.2
+  resolution: "domutils@npm:3.2.2"
+  dependencies:
+    dom-serializer: "npm:^2.0.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+  checksum: 10c0/47938f473b987ea71cd59e59626eb8666d3aa8feba5266e45527f3b636c7883cca7e582d901531961f742c519d7514636b7973353b648762b2e3bedbf235fada
   languageName: node
   linkType: hard
 
@@ -3321,6 +3390,13 @@ __metadata:
   version: 2.2.0
   resolution: "entities@npm:2.2.0"
   checksum: 10c0/7fba6af1f116300d2ba1c5673fc218af1961b20908638391b4e1e6d5850314ee2ac3ec22d741b3a8060479911c99305164aed19b6254bde75e7e6b1b2c3f3aa3
+  languageName: node
+  linkType: hard
+
+"entities@npm:^4.2.0, entities@npm:^4.4.0":
+  version: 4.5.0
+  resolution: "entities@npm:4.5.0"
+  checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
   languageName: node
   linkType: hard
 
@@ -3833,6 +3909,13 @@ __metadata:
     snapdragon: "npm:^0.8.1"
     to-regex: "npm:^3.0.1"
   checksum: 10c0/e1a891342e2010d046143016c6c03d58455c2c96c30bf5570ea07929984ee7d48fad86b363aee08f7a8a638f5c3a66906429b21ecb19bc8e90df56a001cd282c
+  languageName: node
+  linkType: hard
+
+"fast-deep-equal@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "fast-deep-equal@npm:2.0.1"
+  checksum: 10c0/1602e0d6ed63493c865cc6b03f9070d6d3926e8cd086a123060b58f80a295f3f08b1ecfb479ae7c45b7fd45535202aea7cf5b49bc31bffb81c20b1502300be84
   languageName: node
   linkType: hard
 
@@ -4413,6 +4496,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-to-text@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "html-to-text@npm:9.0.5"
+  dependencies:
+    "@selderee/plugin-htmlparser2": "npm:^0.11.0"
+    deepmerge: "npm:^4.3.1"
+    dom-serializer: "npm:^2.0.0"
+    htmlparser2: "npm:^8.0.2"
+    selderee: "npm:^0.11.0"
+  checksum: 10c0/5d2c77b798cf88a81b1da2fc1ea1a3b3e2ff49fe5a3d812392f802fff18ec315cf0969bd7846ef2eb7df8c37f463bc63e8cbdcf84e42696c6f3e15dfa61cdf4f
+  languageName: node
+  linkType: hard
+
 "htmlparser2@npm:^6.0.0":
   version: 6.0.0
   resolution: "htmlparser2@npm:6.0.0"
@@ -4422,6 +4518,18 @@ __metadata:
     domutils: "npm:^2.4.4"
     entities: "npm:^2.0.0"
   checksum: 10c0/8d5a44697b849bac90e3b27fe768a139536c611e1ac22867f1cba51ef3d48ec12a37f1cdc73235b566b0e9d4303b9e09b03ddcbd71392f3ca88106ebb945bd8a
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "htmlparser2@npm:8.0.2"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.0.1"
+    entities: "npm:^4.4.0"
+  checksum: 10c0/609cca85886d0bf2c9a5db8c6926a89f3764596877492e2caa7a25a789af4065bc6ee2cdc81807fe6b1d03a87bf8a373b5a754528a4cc05146b713c20575aab4
   languageName: node
   linkType: hard
 
@@ -5017,6 +5125,13 @@ __metadata:
   dependencies:
     language-subtag-registry: "npm:~0.3.2"
   checksum: 10c0/04215e821af9a8f1bc6c99ab5aa0a316c3fe1912ca3337eb28596316064bddd8edd22f2883d866069ebdf01b2002e504a760a336b2c728b6d30514e86744f76c
+  languageName: node
+  linkType: hard
+
+"leac@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "leac@npm:0.6.0"
+  checksum: 10c0/5257781e10791ef8462eb1cbe5e48e3cda7692486f2a775265d6f5216cc088960c62f138163b8df0dcf2119d18673bfe7b050d6b41543d92a7b7ac90e4eb1e8b
   languageName: node
   linkType: hard
 
@@ -5908,6 +6023,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parseley@npm:^0.12.0":
+  version: 0.12.1
+  resolution: "parseley@npm:0.12.1"
+  dependencies:
+    leac: "npm:^0.6.0"
+    peberminta: "npm:^0.9.0"
+  checksum: 10c0/df3de74172b72305b867298a71e5882c413df75d30f2bafb5fb70779dfd349c5e4db03441fbf8ca83da8e4aa72bd0ef2b5c73086c4825d27d1c649d61bc0bcc0
+  languageName: node
+  linkType: hard
+
 "pascalcase@npm:^0.1.1":
   version: 0.1.1
   resolution: "pascalcase@npm:0.1.1"
@@ -5970,6 +6095,13 @@ __metadata:
   version: 1.2.0
   resolution: "pathseg@npm:1.2.0"
   checksum: 10c0/2842f35e77fbac06a753d40d130b55c8543aaaefe3b01683bdbb1cd9f06b97ff0fa885c33e66082c622caa4a8ae97dc93e8aec3024a097ba2b6b3d0e8c3806ad
+  languageName: node
+  linkType: hard
+
+"peberminta@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "peberminta@npm:0.9.0"
+  checksum: 10c0/59c2c39269d9f7f559cf44582f1c0503524c6a9bc3478e0309adba2b41c71ab98745a239a4e6f98f46105291256e6d8f12ae9860d9f016b1c9a6f52c0b63bfe7
   languageName: node
   linkType: hard
 
@@ -6052,6 +6184,15 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: 10c0/4041ff87d6cba9134a8e0eb74a9e7f50f7091de6b95f5a6fb1928795c7d0584ae46806e0d75588fbc912b2cda2439d28a14fb84416946384cf71d60f5a0a68a6
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "prettier@npm:3.5.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/3880cb90b9dc0635819ab52ff571518c35bd7f15a6e80a2054c05dbc8a3aa6e74f135519e91197de63705bcb38388ded7e7230e2178432a1468005406238b877
   languageName: node
   linkType: hard
 
@@ -6160,6 +6301,15 @@ __metadata:
   peerDependencies:
     react: ^16.0.0
   checksum: 10c0/511673d1f676003220fd7faba2886ec4fdf1fb98540a84051baa3a9da7320225d8421992d4d88d81da63acedb9c5ced4a093ef113ccf4d511f4359db28422334
+  languageName: node
+  linkType: hard
+
+"react-promise-suspense@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "react-promise-suspense@npm:0.3.4"
+  dependencies:
+    fast-deep-equal: "npm:^2.0.1"
+  checksum: 10c0/ab7a22f5400f9e9933995537bf6430a4c79e33a121aedb51864968e7604e5c40421fd539ead62554f32300b7d49755c79636de06caa36fe52973b626b4ddfebf
   languageName: node
   linkType: hard
 
@@ -6378,6 +6528,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resend@npm:^4.5.2":
+  version: 4.5.2
+  resolution: "resend@npm:4.5.2"
+  dependencies:
+    "@react-email/render": "npm:1.1.2"
+  checksum: 10c0/ecf937d438578062629770d5fca81df545d7012f3b574f05e69c920c4007426254d668bf9d7ea852d2ed6dc46facfd260a691051b976f64fdf68bf1c6f726294
+  languageName: node
+  linkType: hard
+
 "resolve-dir@npm:^1.0.0, resolve-dir@npm:^1.0.1":
   version: 1.0.1
   resolution: "resolve-dir@npm:1.0.1"
@@ -6569,6 +6728,15 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
+  languageName: node
+  linkType: hard
+
+"selderee@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "selderee@npm:0.11.0"
+  dependencies:
+    parseley: "npm:^0.12.0"
+  checksum: 10c0/c2ad8313a0dbf3c0b74752a8d03cfbc0931ae77a36679cdb64733eb732c1762f95a5174249bf7e8b8103874cb0e013a030f9c8b72f5d41e62f1d847d4a845d39
   languageName: node
   linkType: hard
 
@@ -6937,6 +7105,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-particles-js: "npm:3.4.1"
+    resend: "npm:^4.5.2"
     stripe: "npm:^18.2.1"
     twind: "npm:0.15.4"
     typescript: "npm:5.8.3"


### PR DESCRIPTION
## Summary
- add tagline and email documentation
- document Resend email support in `.env.example`
- create Resend email API route
- create webhook to receive inbound mail
- connect pricing table to Stripe checkout
- allow button `onClick` prop
- update Stripe webhook initialization

## Testing
- `yarn lint`
- `yarn type-check`
- `yarn build` *(fails: Supabase URL missing)*

------
https://chatgpt.com/codex/tasks/task_b_68475e6dd530832fb11ac4cfa8f13e62